### PR TITLE
Bump homebank version to 5.5.4.

### DIFF
--- a/fr.free.Homebank.json
+++ b/fr.free.Homebank.json
@@ -80,8 +80,8 @@
         "sources": [
             {
                 "type": "archive",
-                "url": "http://homebank.free.fr/public/homebank-5.5.1.tar.gz",
-                "sha256": "9bb39eaad3c4c68d2bcbe21e2f6c4a5274e3a3f385afb2b2ff73ae5fd998da08"
+                "url": "http://homebank.free.fr/public/homebank-5.5.4.tar.gz",
+                "sha256": "1c753807d6ec40fcfcf4a3937d61fc3e797c7e2d68f2094f22bb663c91115252"
             }
         ],
         "post-install": [


### PR DESCRIPTION
This is my first pull request so please accept my apologies for any errors here.

This is to bump the Homebank version from 5.5.1 to 5.5.4.